### PR TITLE
(setq buffer-name ...) changed to (rename-buffer ...)

### DIFF
--- a/emacs-pager.el
+++ b/emacs-pager.el
@@ -54,7 +54,7 @@
                                 (forward-line emacs-pager-max-line-coloring)
                                 (point)))
 
-  (setq buffer-name "*pager*")
+  (rename-buffer "*pager*")
   (read-only-mode))
 
 (provide 'emacs-pager)


### PR DESCRIPTION
`(buffer-name)` returns the name of the current buffer, it doesn't make sense to set it. The proper way to set a buffer name is with `(rename-buffer new-name)`.

PS: Awesome repo, I was about to reimplement the exact same thing. :+1:
