### PR TITLE
emacs-pager: replace insecure Ruby script with sh version

### DIFF
--- a/emacs-pager
+++ b/emacs-pager
@@ -1,17 +1,13 @@
-#!/usr/bin/env ruby
+#!/bin/sh
+#
+# Depends:
+#  mktemp
+#  emacsclient
 
-require 'digest/md5'
-require 'fileutils'
+file=$(mktemp -t "$USER-"XXXXXXXX.emacs-pager) || exit 127
+trap 'rm -f "$file"' EXIT
+trap 'exit 255' HUP INT QUIT TERM
+cat "$@" >"$file"
+emacsclient "$file"
 
-input = ARGF.read
-file = "/tmp/#{Digest::MD5.hexdigest input}.emacs-pager"
 
-File.open(file, 'w') do |f|
-  f.write(input)
-end
-
-puts 'reading into emacs...'
-
-`emacsclient #{file}`
-
-FileUtils.rm(file)


### PR DESCRIPTION
Use mktemp to create a unique and secure temporary file; avoid clobbering
an existing file if the same command is run in parallel sessions, and
avoid creating a temporary file with insecure permissions and/or a
predictable name.

Also, use shell traps to clean up properly even if interrupted.
